### PR TITLE
Fixing broken links for NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/oxidauth/client-js.git"
+    "url": "git+https://github.com/oxidauth/oxidauth-js.git"
   },
   "keywords": [
     "oxidauth",
@@ -20,9 +20,9 @@
   "author": "George Wheeler",
   "license": "UNLICENSED",
   "bugs": {
-    "url": "https://github.com/oxidauth/client-js/issues"
+    "url": "https://github.com/oxidauth/oxidauth-js/issues"
   },
-  "homepage": "https://github.com/oxidauth/client-js#readme",
+  "homepage": "https://github.com/oxidauth/oxidauth-js#readme",
   "dependencies": {
     "jose": "^5.2.1"
   }


### PR DESCRIPTION
Currently the repo links on the NPM page are broken, this should fix.