### PR TITLE
add check_permission method to oxidauthclient

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,7 +118,7 @@ export class OxidAuthClient {
                 return res.payload
             })
             .catch((err) => {
-                throw new OxidAuthError('FETCH_PUBLIC_KEYS_ERR', err)
+                throw new OxidAuthError('EXCHANGE_REFRESH_TOKEN_ERR', err)
             })
 
         await this.setToken(jwt)
@@ -246,6 +246,29 @@ export class OxidAuthClient {
 
     async unlock() {
         return await this._storage.set(OXIDAUTH_MUTEX_KEY, false)
+    }
+
+    async checkPermission(permission) {
+        const url = `${this._host}/api/v1/can/${permission}`
+
+        if (!permission) {
+            throw new OxidAuthError('NO_PERMISSION_TO_CHECK', 'no permission provided to check against')
+        }
+
+        const opts = { headers: { 'Content-Type': 'application/json' } }
+
+        return fetch(url, opts)
+            .then((res) => res.json())
+            .then((res) => {
+                if (res.success === false) {
+                    throw new OxidAuthError('CHECK_PERMISSION_ERR', res?.errors)
+                }
+
+                return res.payload
+            })
+            .catch((err) => {
+                throw new OxidAuthError('CHECK_PERMISSION_ERR', err)
+            })
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -255,7 +255,17 @@ export class OxidAuthClient {
             throw new OxidAuthError('NO_PERMISSION_TO_CHECK', 'no permission provided to check against')
         }
 
-        const opts = { headers: { 'Content-Type': 'application/json' } }
+        const headers = {
+            'Content-Type': 'application/json',
+        }
+
+        const token = await this.fetchValidJWT()
+
+        if (token !== undefined && token !== null && token.trim() !== '') {
+            headers['Authorization'] = `Bearer ${token}`
+        }
+
+        const opts = { headers }
 
         return fetch(url, opts)
             .then((res) => res.json())


### PR DESCRIPTION
Adds method to oxidauth client to enable checking a user's permissions

Wasn't sure if we wanted to name the functions `can` all the way through, so I can update it if we do